### PR TITLE
Paginate dataset queries returning >10k datasets

### DIFF
--- a/retracted.py
+++ b/retracted.py
@@ -266,7 +266,11 @@ def get_retracted_multi_facets( prefix, fcts, constraints='', complement_query=T
             else:
                 return get_some_retracted_paginated( prefix, constraints, test )
         except numFoundException as e:
-            raise e
+            # There are too many query results; we have to constrain another facet.
+            if len(fcts)>0:
+                pass
+            else:
+                raise e
     facet = fcts[0][0]
     facets = fcts[0][1]
     numFoundall = 0

--- a/retracted.py
+++ b/retracted.py
@@ -191,7 +191,7 @@ def get_some_retracted_paginated( prefix, constraints='', test=True ):
         if num_lines==0:
             # No more datasets to be found
             break
-        numFoundmax = max( numFoundmax, numFound )
+        numFoundMax = max( numFoundMax, numFound )
         try:
             Nchanges = retract_path(path, test)
         except Exception as e:

--- a/retracted.py
+++ b/retracted.py
@@ -130,10 +130,10 @@ def get_retracted( prefix,
     for N in range(npages):
         path = prefix+str(starting_offset)
         num_lines, numFound = one_query( cmd, path )
+        numFoundmax = max( numFoundmax, numFound )
         if num_lines==0:
             # No more datasets to be found
             break
-        numFoundmax = max( numFoundmax, numFound )
         try:
             Nchanges = retract_path(path, test)
         except Exception as e:
@@ -188,10 +188,10 @@ def get_some_retracted_paginated( prefix, constraints='', test=True ):
         num_lines, numFound = one_query( cmd, path )
         logging.info( "get_some_retracted_paginated; constraints=%s, num_lines=%s, numFound=%s"%
                     (constraints, num_lines, numFound ) )
+        numFoundMax = max( numFoundMax, numFound )
         if num_lines==0:
             # No more datasets to be found
             break
-        numFoundMax = max( numFoundMax, numFound )
         try:
             Nchanges = retract_path(path, test)
         except Exception as e:


### PR DESCRIPTION
Originally, retracted.py handled large dataset counts by splitting up queries by their facets.  However, recent queries have exceeded 10k datasets even after splitting the queries into one value per facet.  This prevents the retraction process since not all of the datasets found in the query can be retrieved by the search API, which has a limit of 10,000.

This change fixes the above issue by paginating queries that exceed 10k datasets.